### PR TITLE
Patch for otherwise valid URLs being corrupted

### DIFF
--- a/django_bitly/models.py
+++ b/django_bitly/models.py
@@ -82,6 +82,9 @@ class BittleManager(models.Manager):
             # These can be used with only one forward slash
             # Treat these as ready-to-go
             url = obj_url
+        elif re.match(r'^https?://', obj_url, re.IGNORECASE):
+            # This is an HTTP link, just send it through.
+            url = obj_url
         elif re.match(r'^[^:/]+://', obj_url, re.IGNORECASE):
             # These are meant to be used with double-forward-slashes
             # Treat these as ready-to-go


### PR DESCRIPTION
For whatever reason, completely valid HTTP links are getting decimated by these regexes. I fixed it.
