### PR TITLE
Import the system version of simplejson instead of Django's

### DIFF
--- a/django_bitly/models.py
+++ b/django_bitly/models.py
@@ -12,7 +12,7 @@ from django.contrib.sites.models import Site
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.conf import settings
-from django.utils import simplejson as json
+import simplejson as json
 
 from .conf import BITLY_TIMEOUT
 from .exceptions import BittleException


### PR DESCRIPTION
Django 1.5 deprecates django.utils.simplejson in favor of Python 2.6’s built-in json module. The change shouldn't cause any harm.