### PR TITLE
Correct imports for django 1.7 and python 3.4

### DIFF
--- a/django_bitly/models.py
+++ b/django_bitly/models.py
@@ -1,6 +1,9 @@
 import re
 import urllib
-import urllib2
+try:
+    import urllib.request as urllib2
+except ImportError:
+    import urllib2
 from datetime import timedelta
 try:
     from django.utils import timezone as datetime
@@ -12,7 +15,10 @@ from django.contrib.sites.models import Site
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.conf import settings
-from django.utils import simplejson as json
+try:
+    from django.utils import simplejson as json
+except ImportError:
+    import json
 
 from .conf import BITLY_TIMEOUT
 from .exceptions import BittleException


### PR DESCRIPTION
Keeps compatibility with older versions. I don't know which version in between are affected.