### PR TITLE
Import basestring if it exists for newer versions of python

### DIFF
--- a/django_bitly/models.py
+++ b/django_bitly/models.py
@@ -1,6 +1,10 @@
 import re
 import urllib
 try:
+    from pyparsing import basestring
+except ImportError:
+    pass
+try:
     import urllib.request as urllib2
 except ImportError:
     import urllib2


### PR DESCRIPTION
There was still an error at runtime that I missed in my last commit.