### PR TITLE
Fix creating multiple bittles when url scheme changes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Other contributions by
 - Luis Nell
 - Martin Koistinen
 - Tommy Santerre
+- Steve Byerly

--- a/django_bitly/models.py
+++ b/django_bitly/models.py
@@ -117,7 +117,7 @@ class BittleManager(models.Manager):
                 # will mean handling multiple Bittles for any given object.
                 # For now we'll delete the old Bittle and create a new one.
                 bittle.delete()
-                bittle = Bittle.objects.bitlify(obj)
+                bittle = Bittle.objects.bitlify(obj, scheme=scheme)
 
             return bittle
         except Bittle.DoesNotExist:


### PR DESCRIPTION
This fixes the following scenario:

You have an object with the following absolute_url:
`/blog/posts/1`

You bitlify the object and do not specify the scheme. You get the following bittle absolue_url:
`http://mysite.com/blog/posts/1`

You bitlify the object again and pass in the scheme as 'https'. The `url` var and `bittle.absolute_url` do not match so it deletes the bittle and creates a new one with the default 'http' scheme.