### PR TITLE
django 1.8 compatible

### DIFF
--- a/django_bitly/models.py
+++ b/django_bitly/models.py
@@ -49,7 +49,7 @@ class BittleManager(models.Manager):
     """
     def filter_for_instance(self, obj):
         app_label = obj._meta.app_label
-        model = obj._meta.module_name
+        model = obj._meta.model_name
         return self.filter(content_type__app_label=app_label, content_type__model=model, object_id=obj.pk)
 
     def get_for_instance(self, obj):


### PR DESCRIPTION
Fixed the Model._meta.module_name alias removed in django 1.8.