### PR TITLE
Bugfix and dump urllib in favor of requests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-README.rst
-LICENSE.txt
+include README.rst
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ from setuptools import setup
 
 
 description, long_description = __doc__.split('\n\n', 1)
-VERSION = '1.1.1'
+VERSION = '1.1.2'
 
 setup(
     name='django-bitly',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ from setuptools import setup
 
 
 description, long_description = __doc__.split('\n\n', 1)
-VERSION = '1.1.0'
+VERSION = '1.1.1'
 
 setup(
     name='django-bitly',
@@ -64,5 +64,5 @@ setup(
         'django_bitly.templatetags',
     ],
     provides=['django_bitly'],
-    install_requires=['django>=1.8', 'six'],
+    install_requires=['django>=1.8', 'six', 'requests'],
 )


### PR DESCRIPTION
Don't reference Bittle model, but use self.model
---

This is very likely the cause of the MultipleObjectsExist bug, as
referencing a manager on a model from that manager allows Python to
parallelize.

Dump urllib
---

It is braindead and always has been. Once again shown by the fact that
it wants POST data in bytes objects.