### PR TITLE
Updated the Bittle model to not use deprecated decorator @models.permalink

### DIFF
--- a/django_bitly/migrations/0001_initial.py
+++ b/django_bitly/migrations/0001_initial.py
@@ -10,15 +10,21 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-        ('contenttypes', '0002_remove_content_type_name'),
-    ]
+    dependencies = [('contenttypes', '0002_remove_content_type_name')]
 
     operations = [
         migrations.CreateModel(
             name='Bittle',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('object_id', models.PositiveIntegerField()),
                 ('absolute_url', models.URLField(max_length=1024)),
                 ('hash', models.CharField(max_length=10)),
@@ -26,19 +32,34 @@ class Migration(migrations.Migration):
                 ('shortUrl', models.URLField()),
                 ('userHash', models.CharField(max_length=10)),
                 ('statstring', models.TextField(blank=True, editable=False)),
-                ('statstamp', models.DateTimeField(blank=True, editable=False, null=True)),
+                (
+                    'statstamp',
+                    models.DateTimeField(blank=True, editable=False, null=True),
+                ),
                 ('date_created', models.DateTimeField(auto_now_add=True)),
                 ('date_modified', models.DateTimeField(auto_now=True)),
-                ('content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='contenttypes.ContentType')),
+                (
+                    'content_type',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to='contenttypes.ContentType',
+                    ),
+                ),
             ],
-            options={
-                'ordering': ('-date_created',),
-            },
+            options={'ordering': ('-date_created',)},
         ),
         migrations.CreateModel(
             name='StringHolder',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('absolute_url', models.URLField(max_length=1024)),
             ],
         ),

--- a/example_project/project/settings.py
+++ b/example_project/project/settings.py
@@ -37,9 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-
     'django_bitly',
-    'testapp'
+    'testapp',
 ]
 
 MIDDLEWARE = [
@@ -57,9 +56,7 @@ ROOT_URLCONF = 'project.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            os.path.join(BASE_DIR, 'templates'),
-        ],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -67,9 +64,9 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = 'project.wsgi.application'
@@ -91,17 +88,11 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'
     },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+    {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator'},
+    {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
+    {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
 ]
 
 

--- a/example_project/project/urls.py
+++ b/example_project/project/urls.py
@@ -29,7 +29,6 @@ object_dict = {'queryset': get_objects()}
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-
     url(r'^$', ListView.as_view(**object_dict)),
     url(r'^(?P<pk>\w+)/$', DetailView.as_view(**object_dict), name="test"),
 ]

--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],
-    packages=[
-        'django_bitly',
-        'django_bitly.migrations',
-        'django_bitly.templatetags',
-    ],
+    packages=['django_bitly', 'django_bitly.migrations', 'django_bitly.templatetags'],
     provides=['django_bitly'],
     install_requires=['django>=1.8', 'six', 'requests'],
 )


### PR DESCRIPTION
Older Behavior:
The version `1.2.0` was using a decorator `@models.permalink` which is now deprecated in Django 2.2.

Changes:
returning `reverse('bittle', None, [self.id])` instead of `'bittle', [self.id]` in `get_absolute_url` function.