### PR TITLE
Updated the Bittle model to not use deprecated decorator @models.permalink

### DIFF
--- a/django_bitly/models.py
+++ b/django_bitly/models.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 import requests
 import six
+from django.urls import reverse
 
 try:
     from django.utils.timezone import now
@@ -221,6 +222,5 @@ class Bittle(models.Model):
         ]
         return referrer_list
 
-    @models.permalink
     def get_absolute_url(self):
-        return 'bittle', [self.id]
+        return reverse('bittle', None, [self.id])


### PR DESCRIPTION
Older Behavior:
The version 1.2.0 was using a decorator @models.permalink which is now deprecated in Django 2.2.

Changes:
returning reverse('bittle', None, [self.id]) instead of 'bittle', [self.id] in get_absolute_url function.